### PR TITLE
get flow temperature from FlowTemperatureSensor or FlowTemperatureVF1

### DIFF
--- a/pymultimatic/model/mapper.py
+++ b/pymultimatic/model/mapper.py
@@ -379,7 +379,8 @@ def _find_boiler_temperature_report(live_report) -> Optional[float]:
         for device in live_report.get("body", dict()).get("devices", list()):
             for report in device.get("reports", list()):
                 if report.get("associated_device_function") == "HEATING" \
-                        and report.get("_id") == "FlowTemperatureSensor":
+                        and (report.get("_id") == "FlowTemperatureSensor"
+                             or report.get("_id") == "FlowTemperatureVF1"):
                     return float(report.get("value"))
     return None
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pymultiMATIC',
-      version='0.0.6',
+      version='0.0.7',
       description='Python interface with Vaillant multiMATIC',
       long_description_content_type='text/markdown',
       long_description=long_description,

--- a/tests/files/responses/livereport_FlowTemperatureVF1
+++ b/tests/files/responses/livereport_FlowTemperatureVF1
@@ -1,0 +1,76 @@
+{
+    "body": {
+        "devices": [
+            {
+                "reports": [
+                    {
+                        "unit": "°C",
+                        "name": "Température ECS ballon",
+                        "value": 44.5,
+                        "_id": "DomesticHotWaterTankTemperature",
+                        "measurement_category": "TEMPERATURE",
+                        "associated_device_function": "DHW"
+                    }
+                ],
+                "_id": "Control_DHW",
+                "name": "Circuit sanitaire"
+            },
+            {
+                "reports": [
+                    {
+                        "unit": "°C",
+                        "name": "Sonde de température de départ",
+                        "value": 41,
+                        "_id": "FlowTemperatureVF1",
+                        "measurement_category": "TEMPERATURE",
+                        "associated_device_function": "HEATING"
+                    }
+                ],
+                "_id": "Control_CC1",
+                "name": "Circuit chauffage 1"
+            },
+            {
+                "reports": [
+                    {
+                        "unit": "bar",
+                        "name": "Pression d'eau",
+                        "value": 1.9,
+                        "_id": "WaterPressureSensor",
+                        "measurement_category": "PRESSURE",
+                        "associated_device_function": "HEATING"
+                    }
+                ],
+                "_id": "Control_SYS_MultiMatic",
+                "name": "multiMATIC"
+            }
+        ]
+    },
+    "meta": {
+        "resourceState": [
+            {
+                "state": "SYNCED",
+                "timestamp": 1546268600,
+                "link": {
+                    "rel": "child",
+                    "resourceLink": "/facilities/1234567890123456789012345678/livereport/v1/devices/Control_DHW/reports/DomesticHotWaterTankTemperature"
+                }
+            },
+            {
+                "state": "SYNCED",
+                "timestamp": 1546268601,
+                "link": {
+                    "rel": "child",
+                    "resourceLink": "/facilities/1234567890123456789012345678/livereport/v1/devices/Control_CC1/reports/FlowTemperatureSensor"
+                }
+            },
+            {
+                "state": "SYNCED",
+                "timestamp": 1546268603,
+                "link": {
+                    "rel": "child",
+                    "resourceLink": "/facilities/1234567890123456789012345678/livereport/v1/devices/Control_SYS_MultiMatic/reports/WaterPressureSensor"
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -373,3 +373,12 @@ class MapperTest(unittest.TestCase):
     def test_boiler_info_no_livereport(self) -> None:
         boiler_info = mapper.map_boiler_info(None)
         self.assertIsNone(boiler_info)
+
+    def test_boiler_info_flow_temperature_vf1(self) -> None:
+        with open(testutil.path(
+                'files/responses/livereport_FlowTemperatureVF1'), 'r') as file:
+            livereport = json.loads(file.read())
+
+        boiler_info = mapper.map_boiler_info(livereport)
+        self.assertEqual(1.9, boiler_info.water_pressure)
+        self.assertEqual(41, boiler_info.current_temperature)


### PR DESCRIPTION
See https://github.com/thomasgermain/pymultiMATIC/issues/13.

Get flow temperature either from `FlowTemperatureSensor` or `FlowTemperatureVF1` value.

I don't know why there is a difference. It is certainly due to the type of device in use