### PR TITLE
set correct target temperature for zone when quick mode one day away

### DIFF
--- a/pymultimatic/model/system.py
+++ b/pymultimatic/model/system.py
@@ -107,7 +107,7 @@ class System:
                 mode = ActiveMode(Zone.MIN_TARGET_TEMP, self.quick_mode)
 
             if self.quick_mode == QuickModes.ONE_DAY_AWAY:
-                mode = ActiveMode(zone.target_min_temperature, self.quick_mode)
+                mode = ActiveMode(Zone.MIN_TARGET_TEMP, self.quick_mode)
 
             if self.quick_mode == QuickModes.SYSTEM_OFF:
                 mode = ActiveMode(Zone.MIN_TARGET_TEMP, self.quick_mode)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pymultiMATIC',
-      version='0.0.8',
+      version='0.0.9',
       description='Python interface with Vaillant multiMATIC',
       long_description_content_type='text/markdown',
       long_description=long_description,

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -307,7 +307,7 @@ class SystemTest(unittest.TestCase):
         active_mode = system.get_active_mode_zone(zone)
 
         self.assertEqual(QuickModes.ONE_DAY_AWAY, active_mode.current_mode)
-        self.assertEqual(zone.target_min_temperature,
+        self.assertEqual(Zone.MIN_TARGET_TEMP,
                          active_mode.target_temperature)
 
     def test_get_active_mode_zone_quick_mode_party(self) -> None:


### PR DESCRIPTION
set correct target temperature for zone when quick mode one day away is activate (= frost protection temperature, 5°C)