### PR TITLE
improve connector

### DIFF
--- a/pymultimatic/api/connector.py
+++ b/pymultimatic/api/connector.py
@@ -10,7 +10,7 @@ from . import ApiError, urls, defaults
 
 _LOGGER = logging.getLogger('Connector')
 
-HEADER = {'content-type': 'application/json'}
+HEADER = {'content-type': 'application/json', 'Accept': 'application/json'}
 
 
 @attr.s
@@ -165,8 +165,9 @@ class Connector:
                 return await self.request(method, url, payload)
 
             if resp.status > 399:
-                # fetch json response so it's available later on
-                await resp.json(content_type=None)
+                # fetch response body, so it's available later on,
+                # since this is an error, this is not always json
+                await resp.read()
                 raise ApiError('Cannot ' + method + ' ' + url, response=resp,
                                payload=payload)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pymultiMATIC',
-      version='0.1.3',
+      version='0.1.4',
       description='Python interface with Vaillant multiMATIC',
       long_description_content_type='text/markdown',
       long_description=long_description,


### PR DESCRIPTION
Calling read() instead of json() when the api returns errors (the response is not always json)
passing accept header to api calls