### PR TITLE
Fix : Senso setPoint and setBack for Zone and add Manual mode

### DIFF
--- a/pymultimatic/api/payloads_senso.py
+++ b/pymultimatic/api/payloads_senso.py
@@ -24,7 +24,7 @@ def zone_temperature_setpoint(temperature: float) -> Dict[str, Any]:
     """Payload used to set target temperature for
     :class:`~pymultimatic.model.component.Zone`.
     """
-    return {"temperature_setpoint": temperature}
+    return {"manual_mode_temperature_setpoint": temperature}
 
 
 def zone_temperature_setback(temperature: float) -> Dict[str, Any]:

--- a/pymultimatic/api/urls_senso.py
+++ b/pymultimatic/api/urls_senso.py
@@ -102,8 +102,10 @@ _ZONE_QUICK_VETO = _ZONE_CONFIGURATION + "/quick_veto"
 _ZONE_HEATING_CONFIGURATION = _ZONE + "/heating/configuration"
 _ZONE_HEATING_TIMEPROGRAM = _ZONE + "/heating/timeprogram"
 _ZONE_HEATING_MODE = _ZONE_HEATING_CONFIGURATION + "/operation_mode"
-_ZONE_HEATING_SETPOINT_TEMPERATURE = _ZONE_HEATING_CONFIGURATION + "/setpoint_temperature"
-_ZONE_HEATING_SETBACK_TEMPERATURE = _ZONE_HEATING_CONFIGURATION + "/setback_temperature"
+_ZONE_HEATING_SETPOINT_TEMPERATURE = (
+    _ZONE_HEATING_CONFIGURATION + "/manual_mode_temperature_setpoint"
+)
+_ZONE_HEATING_SETBACK_TEMPERATURE = _ZONE_HEATING_CONFIGURATION + "/setback_temperature_setpoint"
 
 """Zone cooling"""
 _ZONE_COOLING_CONFIGURATION = _ZONE + "/cooling/configuration"

--- a/pymultimatic/model/zone.py
+++ b/pymultimatic/model/zone.py
@@ -25,6 +25,7 @@ class ZoneHeating(Function):
         OperatingModes.AUTO,
         OperatingModes.OFF,
         OperatingModes.DAY,
+        OperatingModes.MANUAL,
         OperatingModes.NIGHT,
         OperatingModes.NORMAL,
         OperatingModes.QUICK_VETO,

--- a/pymultimatic/systemmanager.py
+++ b/pymultimatic/systemmanager.py
@@ -656,7 +656,7 @@ class SystemManager:
             zone_id (str): id of the zone.
             new_mode (OperatingMode): The new mode to set.
         """
-        if new_mode in ZoneHeating.MODES and new_mode != OperatingModes.QUICK_VETO:
+        if zone_id and new_mode in ZoneHeating.MODES and new_mode != OperatingModes.QUICK_VETO:
             _LOGGER.debug(f"New mode is {new_mode}")
             await self._call_api(
                 self.urls.zone_heating_mode,


### PR DESCRIPTION
Corrected urls and payloads for set_zone_heating_setpoint_temperature and set_zone_heating_setback_temperature methods for Senso. During the tests, I noticed that the Manual mode was not taken into account.

Resolve: #108 